### PR TITLE
Add thought: Desperation vs urgency

### DIFF
--- a/content/thoughts/2026-01-02-desperation-vs-urgency.md
+++ b/content/thoughts/2026-01-02-desperation-vs-urgency.md
@@ -1,0 +1,32 @@
+---
+title: "Desperation vs urgency"
+date: 2026-01-02T03:22:17+0000
+draft: false
+description: ""
+tags: ["Startups", "Sales", "Entrepreneurship", "Go-to-market", "Marketing"]
+categories: ["Thoughts"]
+ShowToc: true
+TocOpen: false
+ShowReadingTime: true
+ShowBreadCrumbs: true
+ShowPostNavLinks: true
+ShowWordCount: true
+---
+
+A great 2-minute post by Ross Lazerowitz, CEO at https://www.miragesecurity.ai/
+
+The playbook for enterprise software is:
+1. Cold outreach
+2. Design Partners
+3. First Cohort
+
+Love it.
+
+But, he calls out that **desperation != urgency**.
+
+Being able to sell and raise doesn’t mean success. It means you might get stuck in a local minima. User need to line up for your product.
+
+His key takeaway is:
+> Go slow to go fast. Don’t spin up marketing and a sales team until you feel that pull. If you can’t close $1M without marketing spend and 10 AEs, you might be building something middling. Don’t get distracted by desperation if you can’t find urgency.
+
+https://rosslazer.com/posts/order-taking/


### PR DESCRIPTION
### Motivation
- Add a new "thought of the day" entry capturing Ross Lazerowitz's short post about the enterprise GTM playbook and the distinction between desperation and urgency.
- Surface the advice that startups should wait for real customer pull before scaling marketing and sales teams.
- Classify and tag the entry so it appears in the site's Thoughts collection for discovery.

### Description
- Add the file `content/thoughts/2026-01-02-desperation-vs-urgency.md` containing front matter and the provided content.
- Front matter sets `draft: false`, `categories: ["Thoughts"]`, and tags `["Startups", "Sales", "Entrepreneurship", "Go-to-market", "Marketing"]`.
- The body includes the three-step enterprise playbook, the emphasis that `desperation != urgency`, a quoted key takeaway, and a link to `https://rosslazer.com/posts/order-taking/`.
- Presentation flags such as `ShowToc: true`, `ShowReadingTime: true`, and `ShowWordCount: true` are enabled in the post metadata.

### Testing
- No automated tests were run for this change because it is a content-only update.
- A site build or lint pass (for example via `hugo`) was not executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695739ac61e88322a0fa7b31764ae9c0)